### PR TITLE
Remove "tweaks" from installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ python3 setup.py
 ```
 If you are on Windows then you have to setup geckodriver first ( Download the latest Version Only )
 Geckodriver download link : https://github.com/mozilla/geckodriver/releases
-## Tweaks
-
-Before Running the 'main.py' file what you need to do is go to the Style folder open banner.py and replace ```path = DeadTrap/Style/logo``` with your own path to the logos folder and do the same for line 11 as well without removing ```{files[index]}' , 'r'```
 
 ## Useage
 type the following commands in your terminal

--- a/Style/banner.py
+++ b/Style/banner.py
@@ -5,10 +5,10 @@ class colors:
     yellow =  '\033[1;33m'
 
 def banner():
-    path ='/DeadTrap/Style/logos/'
-    files = os.listdir(path)
+    logos_path = os.path.join(os.path.dirname(__file__), 'logos/')
+    files = os.listdir(logos_path)
     index = random.randrange(0, len(files))
-    f = open(f'/DeadTrap/Style/logos/{files[index]}' , 'r')
+    f = open(os.path.join(f'{logos_path}', f'{files[index]}') , 'r')
     contents = f.read()
     print(colors.yellow + contents)
     f.close()


### PR DESCRIPTION
Modifying code as part of the installation process can be a significant
barrier for people with little or no programming experience. Instead of
the "tweaks" supplied in the installation instructions, this commit
fixes banner.py so that it can programatically determine the location of
the DeadTrap/Style/logos directory.