### PR TITLE
Add installation step for bs4 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ OS_bit = (round(math.log(sys.maxsize,2)+1))
 
 os.system("sudo apt install python3-pip")   
 os.system("pip3 install -U selenium")
+os.system("pip3 install -U bs4")
 
 print("\n \n {} \n \n".format(OS_bit))
 


### PR DESCRIPTION
DeadTrap relies on beautifulsoup, but the install script does not
install it.