### PR TITLE
Configurable numverify API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ python3 setup.py
 If you are on Windows then you have to setup geckodriver first ( Download the latest Version Only )
 Geckodriver download link : https://github.com/mozilla/geckodriver/releases
 
+### Numverify API
+DeadTrap relies on the [numverify api](https://numverify.com/documentation) to discover
+some details about phone numbers. A default API key is included with DeadTrap for
+convenience, but it allows a limited number of API calls each month and may be
+exhausted by other DeadTrap users. It is recommended that you get your own free
+numverify API key by going to the [numverify product page](https://numverify.com/product).
+
+Once you have your numverify API key, you can copy it into `./deadtrap.conf`. Then,
+perform the following steps:
+
+```
+mkdir -p $HOME/.config/deadtrap
+cp ./deadtrap.conf $HOME/.config/deadtrap/deadtrap.conf
+```
+
+DeadTrap will now use your numverify API key to access the numverify API.
+
 ## Useage
 type the following commands in your terminal
 ```

--- a/deadtrap.conf
+++ b/deadtrap.conf
@@ -1,0 +1,2 @@
+[deadtrap]
+numverify_api_key = YOUR_API_KEY_HERE

--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ def get_config():
 
 
 def query_numverify(numverify_api_key, phone_number):
-    response = requests.get(f'http://apilayer.net/api/validate?access_key={numverify_api_key}&number={query}')
+    response = requests.get(f'http://apilayer.net/api/validate?access_key={numverify_api_key}&number={phone_number}')
 
     if response.status_code != 200:
         raise Exception(f"Got HTTP status code {response.status_code} from numverify API")

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ os.system("sudo apt install python3-pip")
 os.system("pip3 install -U selenium")
 os.system("pip3 install -U bs4")
 os.system("pip3 install -U configobj")
+os.system("pip3 install -U requests")
 
 print("\n \n {} \n \n".format(OS_bit))
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ OS_bit = (round(math.log(sys.maxsize,2)+1))
 os.system("sudo apt install python3-pip")   
 os.system("pip3 install -U selenium")
 os.system("pip3 install -U bs4")
+os.system("pip3 install -U configobj")
 
 print("\n \n {} \n \n".format(OS_bit))
 


### PR DESCRIPTION
Provide documentation about how DeadTrap uses the numverify API. Allow users to set the numverify API key in a config file so that they don't have to edit source code to successfully use DeadTrap.

Fixes #11
Fixes #13
Fixes #14
Fixes #17
Fixes #18 